### PR TITLE
Webpack fix, resolve #94

### DIFF
--- a/create/utils/generate-package-json.js
+++ b/create/utils/generate-package-json.js
@@ -68,8 +68,8 @@ module.exports = function generatePackageJson(options) {
       ] : []),
       'terser-webpack-plugin',
       'url-loader',
-      'webpack',
-      'webpack-cli',
+      'webpack@4',
+      'webpack-cli@3',
       'webpack-dev-server',
       ...(type.indexOf('pwa') >= 0 ? [
         'workbox-webpack-plugin',


### PR DESCRIPTION
New release of `webpack@5` and `webpack-cli@4` breaks the current version of `framework-cli@3.4.2`. This pull request will resolve it.

Continue use webpack@4 and webpack-cli@3, resolves issue #93